### PR TITLE
chore: configure MySQL connection pool

### DIFF
--- a/src/config/db.js
+++ b/src/config/db.js
@@ -1,1 +1,20 @@
-// TODO: MySQL connection pool
+const mysql = require('mysql2/promise');
+
+const pool = mysql.createPool({
+  host: process.env.DB_HOST,
+  port: parseInt(process.env.DB_PORT || '3306', 10),
+  user: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_NAME,
+  waitForConnections: true,
+  connectionLimit: 10,
+  queueLimit: 0,
+  timezone: '+00:00',
+});
+
+const testConnection = async () => {
+  const conn = await pool.getConnection();
+  conn.release();
+};
+
+module.exports = { pool, testConnection };

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ const express = require('express');
 const cors = require('cors');
 const morgan = require('morgan');
 const { validateEnv } = require('./config/env');
+const { testConnection } = require('./config/db');
 const routes = require('./routes/index');
 const errorHandler = require('./middlewares/errorHandler');
 
@@ -18,9 +19,18 @@ app.use(express.json());
 app.use('/api', routes);
 app.use(errorHandler);
 
-app.listen(PORT, () => {
+const start = async () => {
+  await testConnection();
+  app.listen(PORT, () => {
+    // eslint-disable-next-line no-console
+    console.log(`Server running on port ${PORT}`);
+  });
+};
+
+start().catch((err) => {
   // eslint-disable-next-line no-console
-  console.log(`Server running on port ${PORT}`);
+  console.error('Failed to start server:', err.message);
+  process.exit(1);
 });
 
 module.exports = app;


### PR DESCRIPTION
## Resumen
Pool de conexiones MySQL con mysql2/promise. El servidor verifica la conexión antes de levantar.

## Issue relacionado
Closes #10

## Tipo de cambio
- [x] Chore / configuración
- [x] Base de datos / migración

## Cambios realizados
- `src/config/db.js`: pool con connectionLimit 10, timezone UTC, exporta `pool` y `testConnection()`
- `src/index.js`: `start()` async que llama `testConnection()` antes de `app.listen()` — si falla, `process.exit(1)`

## Checklist
- [x] La rama está actualizada con `develop`
- [x] Listo para code review