### PR TITLE
db: implement all data models with upsert and query methods

### DIFF
--- a/src/models/apiUsage.model.js
+++ b/src/models/apiUsage.model.js
@@ -1,0 +1,30 @@
+const { pool } = require('../config/db');
+
+const getTodayUsage = async () => {
+  const today = new Date().toISOString().slice(0, 10);
+  const [rows] = await pool.execute(
+    'SELECT * FROM api_usage WHERE date = ?',
+    [today]
+  );
+  return rows[0] || null;
+};
+
+const incrementUsage = async () => {
+  const today = new Date().toISOString().slice(0, 10);
+  await pool.execute(
+    `INSERT INTO api_usage (date, request_count)
+     VALUES (?, 1)
+     ON DUPLICATE KEY UPDATE
+       request_count = request_count + 1,
+       last_updated = CURRENT_TIMESTAMP`,
+    [today]
+  );
+};
+
+const isUnderLimit = async (limit) => {
+  const usage = await getTodayUsage();
+  const count = usage ? usage.request_count : 0;
+  return count < limit;
+};
+
+module.exports = { getTodayUsage, incrementUsage, isUnderLimit };

--- a/src/models/fixtures.model.js
+++ b/src/models/fixtures.model.js
@@ -1,1 +1,137 @@
-// TODO: Fixtures model
+const { pool } = require('../config/db');
+
+const upsertFixture = async (fixture) => {
+  const sql = `
+    INSERT INTO fixtures (
+      id, referee, date, timestamp, venue_name, venue_city,
+      status_long, status_short, status_elapsed,
+      home_team_id, home_team_name, home_team_logo,
+      away_team_id, away_team_name, away_team_logo,
+      home_goals, away_goals, season, league_id, round
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON DUPLICATE KEY UPDATE
+      referee = VALUES(referee),
+      status_long = VALUES(status_long),
+      status_short = VALUES(status_short),
+      status_elapsed = VALUES(status_elapsed),
+      home_goals = VALUES(home_goals),
+      away_goals = VALUES(away_goals),
+      updated_at = CURRENT_TIMESTAMP
+  `;
+  const params = [
+    fixture.id, fixture.referee, fixture.date, fixture.timestamp,
+    fixture.venue_name, fixture.venue_city,
+    fixture.status_long, fixture.status_short, fixture.status_elapsed,
+    fixture.home_team_id, fixture.home_team_name, fixture.home_team_logo,
+    fixture.away_team_id, fixture.away_team_name, fixture.away_team_logo,
+    fixture.home_goals, fixture.away_goals,
+    fixture.season, fixture.league_id, fixture.round,
+  ];
+  await pool.execute(sql, params);
+};
+
+const upsertFixtureEvents = async (fixtureId, events) => {
+  await pool.execute('DELETE FROM fixture_events WHERE fixture_id = ?', [fixtureId]);
+  if (!events.length) return;
+
+  const placeholders = events.map(() => '(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)').join(', ');
+  const values = events.flatMap((e) => [
+    fixtureId, e.time_elapsed, e.time_extra,
+    e.team_id, e.team_name,
+    e.player_id, e.player_name,
+    e.assist_id, e.assist_name,
+    e.type, e.detail, e.comments,
+  ]);
+  await pool.execute(
+    `INSERT INTO fixture_events
+      (fixture_id, time_elapsed, time_extra, team_id, team_name,
+       player_id, player_name, assist_id, assist_name, type, detail, comments)
+     VALUES ${placeholders}`,
+    values
+  );
+};
+
+const upsertFixtureStatistics = async (fixtureId, statistics) => {
+  await pool.execute('DELETE FROM fixture_statistics WHERE fixture_id = ?', [fixtureId]);
+  if (!statistics.length) return;
+
+  const placeholders = statistics.map(() => '(?, ?, ?, ?, ?)').join(', ');
+  const values = statistics.flatMap((s) => [
+    fixtureId, s.team_id, s.team_name, s.stat_type, s.stat_value,
+  ]);
+  await pool.execute(
+    `INSERT INTO fixture_statistics (fixture_id, team_id, team_name, stat_type, stat_value)
+     VALUES ${placeholders}`,
+    values
+  );
+};
+
+const getFixtureById = async (id) => {
+  const [rows] = await pool.execute('SELECT * FROM fixtures WHERE id = ?', [id]);
+  return rows[0] || null;
+};
+
+const getFixtureEvents = async (fixtureId) => {
+  const [rows] = await pool.execute(
+    'SELECT * FROM fixture_events WHERE fixture_id = ? ORDER BY time_elapsed ASC',
+    [fixtureId]
+  );
+  return rows;
+};
+
+const getFixtureStatistics = async (fixtureId) => {
+  const [rows] = await pool.execute(
+    'SELECT * FROM fixture_statistics WHERE fixture_id = ?',
+    [fixtureId]
+  );
+  return rows;
+};
+
+const getRecentFixtures = async (teamId, season, limit = 10) => {
+  const [rows] = await pool.execute(
+    `SELECT * FROM fixtures
+     WHERE (home_team_id = ? OR away_team_id = ?)
+       AND season = ?
+       AND status_short IN ('FT', 'AET', 'PEN')
+     ORDER BY date DESC
+     LIMIT ?`,
+    [teamId, teamId, season, limit]
+  );
+  return rows;
+};
+
+const getUpcomingFixtures = async (teamId, season, limit = 5) => {
+  const [rows] = await pool.execute(
+    `SELECT * FROM fixtures
+     WHERE (home_team_id = ? OR away_team_id = ?)
+       AND season = ?
+       AND status_short IN ('NS', 'TBD')
+     ORDER BY date ASC
+     LIMIT ?`,
+    [teamId, teamId, season, limit]
+  );
+  return rows;
+};
+
+const getFixturesBySeason = async (teamId, season) => {
+  const [rows] = await pool.execute(
+    `SELECT * FROM fixtures
+     WHERE (home_team_id = ? OR away_team_id = ?)
+       AND season = ?
+     ORDER BY date ASC`,
+    [teamId, teamId, season]
+  );
+  return rows;
+};
+
+module.exports = {
+  upsertFixture,
+  upsertFixtureEvents,
+  upsertFixtureStatistics,
+  getFixtureById,
+  getFixtureEvents,
+  getFixtureStatistics,
+  getRecentFixtures,
+  getUpcomingFixtures,
+  getFixturesBySeason,
+};

--- a/src/models/players.model.js
+++ b/src/models/players.model.js
@@ -1,1 +1,60 @@
-// TODO: Players model
+const { pool } = require('../config/db');
+
+const upsertPlayer = async (player) => {
+  const sql = `
+    INSERT INTO players (
+      id, name, firstname, lastname, age, nationality, position, photo,
+      season, team_id, appearances, lineups, minutes,
+      goals, assists, yellow_cards, red_cards,
+      shots_total, shots_on, passes_total, passes_accuracy,
+      tackles_total, dribbles_success, rating
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON DUPLICATE KEY UPDATE
+      name = VALUES(name),
+      age = VALUES(age),
+      appearances = VALUES(appearances),
+      lineups = VALUES(lineups),
+      minutes = VALUES(minutes),
+      goals = VALUES(goals),
+      assists = VALUES(assists),
+      yellow_cards = VALUES(yellow_cards),
+      red_cards = VALUES(red_cards),
+      shots_total = VALUES(shots_total),
+      shots_on = VALUES(shots_on),
+      passes_total = VALUES(passes_total),
+      passes_accuracy = VALUES(passes_accuracy),
+      tackles_total = VALUES(tackles_total),
+      dribbles_success = VALUES(dribbles_success),
+      rating = VALUES(rating),
+      updated_at = CURRENT_TIMESTAMP
+  `;
+  const params = [
+    player.id, player.name, player.firstname, player.lastname,
+    player.age, player.nationality, player.position, player.photo,
+    player.season, player.team_id,
+    player.appearances, player.lineups, player.minutes,
+    player.goals, player.assists, player.yellow_cards, player.red_cards,
+    player.shots_total, player.shots_on,
+    player.passes_total, player.passes_accuracy,
+    player.tackles_total, player.dribbles_success, player.rating,
+  ];
+  await pool.execute(sql, params);
+};
+
+const getPlayersBySeason = async (teamId, season) => {
+  const [rows] = await pool.execute(
+    'SELECT * FROM players WHERE team_id = ? AND season = ? ORDER BY appearances DESC',
+    [teamId, season]
+  );
+  return rows;
+};
+
+const getPlayerById = async (id, season) => {
+  const [rows] = await pool.execute(
+    'SELECT * FROM players WHERE id = ? AND season = ?',
+    [id, season]
+  );
+  return rows[0] || null;
+};
+
+module.exports = { upsertPlayer, getPlayersBySeason, getPlayerById };

--- a/src/models/standings.model.js
+++ b/src/models/standings.model.js
@@ -1,1 +1,64 @@
-// TODO: Standings model
+const { pool } = require('../config/db');
+
+const upsertStanding = async (standing) => {
+  const sql = `
+    INSERT INTO standings (
+      season, league_id, team_id, team_name, team_logo,
+      rank, points, goals_diff, form, status, description,
+      played, win, draw, lose, goals_for, goals_against,
+      home_played, home_win, home_draw, home_lose, home_goals_for, home_goals_against,
+      away_played, away_win, away_draw, away_lose, away_goals_for, away_goals_against
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON DUPLICATE KEY UPDATE
+      team_name = VALUES(team_name),
+      team_logo = VALUES(team_logo),
+      rank = VALUES(rank),
+      points = VALUES(points),
+      goals_diff = VALUES(goals_diff),
+      form = VALUES(form),
+      status = VALUES(status),
+      description = VALUES(description),
+      played = VALUES(played),
+      win = VALUES(win),
+      draw = VALUES(draw),
+      lose = VALUES(lose),
+      goals_for = VALUES(goals_for),
+      goals_against = VALUES(goals_against),
+      home_played = VALUES(home_played),
+      home_win = VALUES(home_win),
+      home_draw = VALUES(home_draw),
+      home_lose = VALUES(home_lose),
+      home_goals_for = VALUES(home_goals_for),
+      home_goals_against = VALUES(home_goals_against),
+      away_played = VALUES(away_played),
+      away_win = VALUES(away_win),
+      away_draw = VALUES(away_draw),
+      away_lose = VALUES(away_lose),
+      away_goals_for = VALUES(away_goals_for),
+      away_goals_against = VALUES(away_goals_against),
+      updated_at = CURRENT_TIMESTAMP
+  `;
+  const params = [
+    standing.season, standing.league_id, standing.team_id,
+    standing.team_name, standing.team_logo,
+    standing.rank, standing.points, standing.goals_diff,
+    standing.form, standing.status, standing.description,
+    standing.played, standing.win, standing.draw, standing.lose,
+    standing.goals_for, standing.goals_against,
+    standing.home_played, standing.home_win, standing.home_draw, standing.home_lose,
+    standing.home_goals_for, standing.home_goals_against,
+    standing.away_played, standing.away_win, standing.away_draw, standing.away_lose,
+    standing.away_goals_for, standing.away_goals_against,
+  ];
+  await pool.execute(sql, params);
+};
+
+const getStandings = async (season, leagueId) => {
+  const [rows] = await pool.execute(
+    'SELECT * FROM standings WHERE season = ? AND league_id = ? ORDER BY rank ASC',
+    [season, leagueId]
+  );
+  return rows;
+};
+
+module.exports = { upsertStanding, getStandings };

--- a/src/models/team.model.js
+++ b/src/models/team.model.js
@@ -1,1 +1,66 @@
-// TODO: Team model
+const { pool } = require('../config/db');
+
+const upsertTeamStats = async (stats) => {
+  const sql = `
+    INSERT INTO team_stats (
+      season, league_id, team_id, form,
+      fixtures_played_home, fixtures_played_away,
+      fixtures_wins_home, fixtures_wins_away,
+      fixtures_draws_home, fixtures_draws_away,
+      fixtures_loses_home, fixtures_loses_away,
+      goals_for_total, goals_against_total,
+      goals_for_avg_home, goals_for_avg_away,
+      biggest_win_home, biggest_win_away,
+      biggest_lose_home, biggest_lose_away,
+      clean_sheet_home, clean_sheet_away,
+      penalty_scored, penalty_missed
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON DUPLICATE KEY UPDATE
+      form = VALUES(form),
+      fixtures_played_home = VALUES(fixtures_played_home),
+      fixtures_played_away = VALUES(fixtures_played_away),
+      fixtures_wins_home = VALUES(fixtures_wins_home),
+      fixtures_wins_away = VALUES(fixtures_wins_away),
+      fixtures_draws_home = VALUES(fixtures_draws_home),
+      fixtures_draws_away = VALUES(fixtures_draws_away),
+      fixtures_loses_home = VALUES(fixtures_loses_home),
+      fixtures_loses_away = VALUES(fixtures_loses_away),
+      goals_for_total = VALUES(goals_for_total),
+      goals_against_total = VALUES(goals_against_total),
+      goals_for_avg_home = VALUES(goals_for_avg_home),
+      goals_for_avg_away = VALUES(goals_for_avg_away),
+      biggest_win_home = VALUES(biggest_win_home),
+      biggest_win_away = VALUES(biggest_win_away),
+      biggest_lose_home = VALUES(biggest_lose_home),
+      biggest_lose_away = VALUES(biggest_lose_away),
+      clean_sheet_home = VALUES(clean_sheet_home),
+      clean_sheet_away = VALUES(clean_sheet_away),
+      penalty_scored = VALUES(penalty_scored),
+      penalty_missed = VALUES(penalty_missed),
+      updated_at = CURRENT_TIMESTAMP
+  `;
+  const params = [
+    stats.season, stats.league_id, stats.team_id, stats.form,
+    stats.fixtures_played_home, stats.fixtures_played_away,
+    stats.fixtures_wins_home, stats.fixtures_wins_away,
+    stats.fixtures_draws_home, stats.fixtures_draws_away,
+    stats.fixtures_loses_home, stats.fixtures_loses_away,
+    stats.goals_for_total, stats.goals_against_total,
+    stats.goals_for_avg_home, stats.goals_for_avg_away,
+    stats.biggest_win_home, stats.biggest_win_away,
+    stats.biggest_lose_home, stats.biggest_lose_away,
+    stats.clean_sheet_home, stats.clean_sheet_away,
+    stats.penalty_scored, stats.penalty_missed,
+  ];
+  await pool.execute(sql, params);
+};
+
+const getTeamStats = async (teamId, season, leagueId) => {
+  const [rows] = await pool.execute(
+    'SELECT * FROM team_stats WHERE team_id = ? AND season = ? AND league_id = ?',
+    [teamId, season, leagueId]
+  );
+  return rows[0] || null;
+};
+
+module.exports = { upsertTeamStats, getTeamStats };


### PR DESCRIPTION
## Resumen
Modelos implementados para todas las entidades del proyecto con operaciones upsert y queries de lectura.

## Issue relacionado
Closes #14

## Tipo de cambio
- [x] Base de datos / migración

## Cambios realizados
- `fixtures.model.js`: upsertFixture, upsertFixtureEvents (delete+insert), upsertFixtureStatistics, getFixtureById, getFixtureEvents, getFixtureStatistics, getRecentFixtures, getUpcomingFixtures, getFixturesBySeason
- `standings.model.js`: upsertStanding (ON DUPLICATE KEY UPDATE), getStandings
- `players.model.js`: upsertPlayer, getPlayersBySeason, getPlayerById
- `team.model.js`: upsertTeamStats, getTeamStats
- `apiUsage.model.js`: getTodayUsage, incrementUsage (atómico), isUnderLimit

## Notas para el reviewer
- `upsertFixtureEvents` y `upsertFixtureStatistics` hacen DELETE+INSERT (no UPSERT) porque los IDs vienen de la API y pueden cambiar entre fetches
- `incrementUsage` usa ON DUPLICATE KEY UPDATE para ser atómico y evitar race conditions
- `isUnderLimit` recibe el límite por parámetro para facilitar tests

## Checklist
- [x] La rama está actualizada con `develop`
- [x] Listo para code review