### PR TITLE
chore: implement API client and rate limit guard

### DIFF
--- a/src/utils/apiClient.js
+++ b/src/utils/apiClient.js
@@ -1,1 +1,11 @@
-// TODO: Axios instance for API Sports
+const axios = require('axios');
+
+const apiClient = axios.create({
+  baseURL: process.env.API_BASE_URL,
+  headers: {
+    'x-apisports-key': process.env.API_KEY,
+  },
+  timeout: 10000,
+});
+
+module.exports = apiClient;

--- a/src/utils/rateLimitGuard.js
+++ b/src/utils/rateLimitGuard.js
@@ -1,1 +1,19 @@
-// TODO: Daily request counter and guard
+const { isUnderLimit, incrementUsage, getTodayUsage } = require('../models/apiUsage.model');
+
+const withRateLimit = async (fn) => {
+  const limit = parseInt(process.env.API_SAFETY_LIMIT || '95', 10);
+  const allowed = await isUnderLimit(limit);
+
+  if (!allowed) {
+    const usage = await getTodayUsage();
+    throw new Error(
+      `Daily API limit reached (${usage ? usage.request_count : limit}/${limit}). Skipping request.`
+    );
+  }
+
+  const result = await fn();
+  await incrementUsage();
+  return result;
+};
+
+module.exports = { withRateLimit };


### PR DESCRIPTION
## Resumen
Cliente HTTP para API-Football y guard que protege el límite diario de 100 requests.

## Issue relacionado
Closes #17

## Tipo de cambio
- [x] Chore / configuración

## Cambios realizados
- `utils/apiClient.js`: axios instance con baseURL y header `x-apisports-key`, timeout 10s
- `utils/rateLimitGuard.js`: `withRateLimit(fn)` verifica `API_SAFETY_LIMIT` (default 95) antes de ejecutar, incrementa el contador tras cada request exitosa — lanza error descriptivo si se alcanzó el límite

## Notas para el reviewer
- El guard usa `API_SAFETY_LIMIT` (no `API_DAILY_LIMIT`) para tener margen antes del hard limit de la API
- `incrementUsage()` se llama después del `await fn()` — si la request falla, el contador no se incrementa

## Checklist
- [x] Las variables de entorno están en `.env.example`
- [x] La rama está actualizada con `develop`
- [x] Listo para code review