### PR TITLE
feat: implement API-Football fetchers

### DIFF
--- a/src/jobs/fetchers/fetchFixtures.js
+++ b/src/jobs/fetchers/fetchFixtures.js
@@ -1,1 +1,61 @@
-// TODO: Fetch fixtures from API Sports
+const apiClient = require('../../utils/apiClient');
+const { withRateLimit } = require('../../utils/rateLimitGuard');
+const {
+  transformFixture,
+  transformFixtureEvent,
+  transformFixtureStat,
+} = require('../../utils/transformers');
+const {
+  upsertFixture,
+  upsertFixtureEvents,
+  upsertFixtureStatistics,
+} = require('../../models/fixtures.model');
+
+const TEAM_ID = parseInt(process.env.MUFC_TEAM_ID || '33', 10);
+const LEAGUE_ID = parseInt(process.env.PREMIER_LEAGUE_ID || '39', 10);
+const SEASON = parseInt(process.env.CURRENT_SEASON || '2024', 10);
+
+const fetchAndSaveFixtureDetail = async (fixtureId) => {
+  const [eventsRes, statsRes] = await Promise.all([
+    withRateLimit(() =>
+      apiClient.get('/fixtures/events', { params: { fixture: fixtureId } })
+    ),
+    withRateLimit(() =>
+      apiClient.get('/fixtures/statistics', { params: { fixture: fixtureId } })
+    ),
+  ]);
+
+  const events = (eventsRes.data.response || []).map(transformFixtureEvent);
+  await upsertFixtureEvents(fixtureId, events);
+
+  const statistics = (statsRes.data.response || []).flatMap((teamStats) =>
+    (teamStats.statistics || []).map((stat) =>
+      transformFixtureStat(stat, teamStats.team.id, teamStats.team.name)
+    )
+  );
+  await upsertFixtureStatistics(fixtureId, statistics);
+};
+
+const fetchFixtures = async () => {
+  const response = await withRateLimit(() =>
+    apiClient.get('/fixtures', {
+      params: { team: TEAM_ID, season: SEASON, league: LEAGUE_ID },
+    })
+  );
+
+  const fixtures = response.data.response || [];
+
+  for (const f of fixtures) {
+    const fixture = transformFixture(f, SEASON, LEAGUE_ID);
+    await upsertFixture(fixture);
+
+    const isFinished = ['FT', 'AET', 'PEN'].includes(fixture.status_short);
+    if (isFinished) {
+      await fetchAndSaveFixtureDetail(fixture.id);
+    }
+  }
+
+  return fixtures.length;
+};
+
+module.exports = { fetchFixtures };

--- a/src/jobs/fetchers/fetchPlayerStats.js
+++ b/src/jobs/fetchers/fetchPlayerStats.js
@@ -1,1 +1,35 @@
-// TODO: Fetch player stats from API Sports
+const apiClient = require('../../utils/apiClient');
+const { withRateLimit } = require('../../utils/rateLimitGuard');
+const { transformPlayer } = require('../../utils/transformers');
+const { upsertPlayer } = require('../../models/players.model');
+
+const TEAM_ID = parseInt(process.env.MUFC_TEAM_ID || '33', 10);
+const SEASON = parseInt(process.env.CURRENT_SEASON || '2024', 10);
+
+const fetchPlayerStats = async () => {
+  let page = 1;
+  let totalPages = 1;
+  let totalSaved = 0;
+
+  do {
+    const response = await withRateLimit(() =>
+      apiClient.get('/players', {
+        params: { team: TEAM_ID, season: SEASON, page },
+      })
+    );
+
+    const players = response.data.response || [];
+    totalPages = response.data.paging?.total || 1;
+
+    for (const p of players) {
+      await upsertPlayer(transformPlayer(p, SEASON, TEAM_ID));
+    }
+
+    totalSaved += players.length;
+    page++;
+  } while (page <= totalPages);
+
+  return totalSaved;
+};
+
+module.exports = { fetchPlayerStats };

--- a/src/jobs/fetchers/fetchStandings.js
+++ b/src/jobs/fetchers/fetchStandings.js
@@ -1,1 +1,26 @@
-// TODO: Fetch standings from API Sports
+const apiClient = require('../../utils/apiClient');
+const { withRateLimit } = require('../../utils/rateLimitGuard');
+const { transformStanding } = require('../../utils/transformers');
+const { upsertStanding } = require('../../models/standings.model');
+
+const LEAGUE_ID = parseInt(process.env.PREMIER_LEAGUE_ID || '39', 10);
+const SEASON = parseInt(process.env.CURRENT_SEASON || '2024', 10);
+
+const fetchStandings = async () => {
+  const response = await withRateLimit(() =>
+    apiClient.get('/standings', {
+      params: { league: LEAGUE_ID, season: SEASON },
+    })
+  );
+
+  const league = response.data.response?.[0]?.league;
+  const standings = league?.standings?.[0] || [];
+
+  for (const standing of standings) {
+    await upsertStanding(transformStanding(standing, SEASON, LEAGUE_ID));
+  }
+
+  return standings.length;
+};
+
+module.exports = { fetchStandings };

--- a/src/jobs/fetchers/fetchTeamStats.js
+++ b/src/jobs/fetchers/fetchTeamStats.js
@@ -1,1 +1,24 @@
-// TODO: Fetch team stats from API Sports
+const apiClient = require('../../utils/apiClient');
+const { withRateLimit } = require('../../utils/rateLimitGuard');
+const { transformTeamStats } = require('../../utils/transformers');
+const { upsertTeamStats } = require('../../models/team.model');
+
+const TEAM_ID = parseInt(process.env.MUFC_TEAM_ID || '33', 10);
+const LEAGUE_ID = parseInt(process.env.PREMIER_LEAGUE_ID || '39', 10);
+const SEASON = parseInt(process.env.CURRENT_SEASON || '2024', 10);
+
+const fetchTeamStats = async () => {
+  const response = await withRateLimit(() =>
+    apiClient.get('/teams/statistics', {
+      params: { team: TEAM_ID, league: LEAGUE_ID, season: SEASON },
+    })
+  );
+
+  const stats = response.data.response;
+  if (!stats) return 0;
+
+  await upsertTeamStats(transformTeamStats(stats, SEASON, LEAGUE_ID, TEAM_ID));
+  return 1;
+};
+
+module.exports = { fetchTeamStats };


### PR DESCRIPTION
## Resumen
Los 4 fetchers que consumen API-Football v3, transforman los datos y los persisten en la DB, todos protegidos por el rate limit guard.

## Issue relacionado
Closes #21

## Tipo de cambio
- [x] Feature nueva

## Cambios realizados
- `fetchFixtures.js`: trae todos los partidos del season; para los terminados (FT/AET/PEN) también fetchea events y statistics en paralelo (2 requests por partido)
- `fetchStandings.js`: trae la tabla de posiciones completa de la Premier League
- `fetchPlayerStats.js`: loop paginado — consume todas las páginas hasta agotar `paging.total`
- `fetchTeamStats.js`: trae estadísticas globales del equipo para el season actual

## Notas para el reviewer
- `fetchFixtures` llama `withRateLimit` una vez por fixture list + 2 veces por partido terminado — en temporada completa puede usar muchos requests. El cron debe ejecutarse con frecuencia baja
- `fetchPlayerStats` usa `do-while` igual que en el frontend para no perder jugadores por paginación
- Todos los fetchers devuelven el número de registros procesados (útil para logs)

## Checklist
- [x] La rama está actualizada con `develop`
- [x] Listo para code review