### PR TITLE
feat: register cron jobs for scheduled API fetching

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ const cors = require('cors');
 const morgan = require('morgan');
 const { validateEnv } = require('./config/env');
 const { testConnection } = require('./config/db');
+const { registerJobs } = require('./jobs/index');
 const routes = require('./routes/index');
 const errorHandler = require('./middlewares/errorHandler');
 
@@ -21,6 +22,7 @@ app.use(errorHandler);
 
 const start = async () => {
   await testConnection();
+  registerJobs();
   app.listen(PORT, () => {
     // eslint-disable-next-line no-console
     console.log(`Server running on port ${PORT}`);

--- a/src/jobs/index.js
+++ b/src/jobs/index.js
@@ -1,1 +1,38 @@
-// TODO: Cron jobs entry point
+const cron = require('node-cron');
+const { fetchFixtures } = require('./fetchers/fetchFixtures');
+const { fetchStandings } = require('./fetchers/fetchStandings');
+const { fetchPlayerStats } = require('./fetchers/fetchPlayerStats');
+const { fetchTeamStats } = require('./fetchers/fetchTeamStats');
+
+const runJob = async (name, fn) => {
+  // eslint-disable-next-line no-console
+  console.log(`[CRON] ${name} started`);
+  try {
+    const count = await fn();
+    // eslint-disable-next-line no-console
+    console.log(`[CRON] ${name} completed — ${count} records processed`);
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(`[CRON] ${name} failed: ${err.message}`);
+  }
+};
+
+const registerJobs = () => {
+  // Fixtures: cada 4 horas (6 veces/día) — cubre jornadas de fin de semana
+  // Requests estimados: 1 (list) + ~2 * partidos terminados
+  cron.schedule('0 */4 * * *', () => runJob('fetchFixtures', fetchFixtures));
+
+  // Standings: una vez por día a las 06:00 UTC
+  cron.schedule('0 6 * * *', () => runJob('fetchStandings', fetchStandings));
+
+  // Players: una vez por día a las 06:30 UTC
+  cron.schedule('30 6 * * *', () => runJob('fetchPlayerStats', fetchPlayerStats));
+
+  // Team stats: una vez por día a las 07:00 UTC
+  cron.schedule('0 7 * * *', () => runJob('fetchTeamStats', fetchTeamStats));
+
+  // eslint-disable-next-line no-console
+  console.log('[CRON] All jobs registered');
+};
+
+module.exports = { registerJobs };


### PR DESCRIPTION
## Resumen
Schedules con node-cron para ejecutar los 4 fetchers de forma controlada dentro del límite diario.

## Issue relacionado
Closes #23

## Tipo de cambio
- [x] Feature nueva

## Cambios realizados
- `jobs/index.js`: 4 crons con schedules escalonados, wrapper `runJob` con log de inicio/fin/error
- `src/index.js`: `registerJobs()` llamado en `start()` luego de verificar la DB

## Schedule definido
| Job | Schedule | Frecuencia |
|-----|----------|------------|
| fetchFixtures | `0 */4 * * *` | Cada 4 horas |
| fetchStandings | `0 6 * * *` | Diario 06:00 UTC |
| fetchPlayerStats | `30 6 * * *` | Diario 06:30 UTC |
| fetchTeamStats | `0 7 * * *` | Diario 07:00 UTC |

## Notas para el reviewer
- Fixtures cada 4h = 6 requests de lista/día + requests de detalle de partidos terminados. Escalonado respecto a standings/players para distribuir la carga
- `runJob` captura errores para que un job que falla no tire el proceso — el servidor sigue corriendo

## Checklist
- [x] La rama está actualizada con `develop`
- [x] Listo para code review