### PR TITLE
feat: implement all services with business logic

### DIFF
--- a/src/services/analytics.service.js
+++ b/src/services/analytics.service.js
@@ -1,1 +1,52 @@
-// TODO: Analytics service
+const { getRecentFixtures, getUpcomingFixtures } = require('../models/fixtures.model');
+const { getStandings } = require('../models/standings.model');
+const { getTeamStats } = require('../models/team.model');
+const { getTodayUsage } = require('../models/apiUsage.model');
+
+const TEAM_ID = parseInt(process.env.MUFC_TEAM_ID || '33', 10);
+const LEAGUE_ID = parseInt(process.env.PREMIER_LEAGUE_ID || '39', 10);
+const SEASON = parseInt(process.env.CURRENT_SEASON || '2024', 10);
+
+const getOverview = async () => {
+  const [recent, upcoming, standings, teamStats, apiUsage] = await Promise.all([
+    getRecentFixtures(TEAM_ID, SEASON, 5),
+    getUpcomingFixtures(TEAM_ID, SEASON, 3),
+    getStandings(SEASON, LEAGUE_ID),
+    getTeamStats(TEAM_ID, SEASON, LEAGUE_ID),
+    getTodayUsage(),
+  ]);
+
+  const mufcStanding = standings.find((s) => s.team_id === TEAM_ID) || null;
+
+  const form = recent
+    .slice()
+    .reverse()
+    .map((f) => {
+      if (f.home_goals === null) return null;
+      const mufcIsHome = f.home_team_id === TEAM_ID;
+      const mufcGoals = mufcIsHome ? f.home_goals : f.away_goals;
+      const oppGoals = mufcIsHome ? f.away_goals : f.home_goals;
+      if (mufcGoals > oppGoals) return 'W';
+      if (mufcGoals < oppGoals) return 'L';
+      return 'D';
+    })
+    .filter(Boolean);
+
+  return {
+    season: SEASON,
+    standing: mufcStanding,
+    form,
+    recent_fixtures: recent,
+    upcoming_fixtures: upcoming,
+    team_stats: teamStats,
+    api_usage: apiUsage
+      ? {
+          requests_today: apiUsage.request_count,
+          daily_limit: parseInt(process.env.API_DAILY_LIMIT || '100', 10),
+          safety_limit: parseInt(process.env.API_SAFETY_LIMIT || '95', 10),
+        }
+      : null,
+  };
+};
+
+module.exports = { getOverview };

--- a/src/services/fixtures.service.js
+++ b/src/services/fixtures.service.js
@@ -1,1 +1,37 @@
-// TODO: Fixtures service
+const {
+  getFixtureById,
+  getFixtureEvents,
+  getFixtureStatistics,
+  getRecentFixtures,
+  getUpcomingFixtures,
+  getFixturesBySeason,
+} = require('../models/fixtures.model');
+
+const TEAM_ID = parseInt(process.env.MUFC_TEAM_ID || '33', 10);
+const SEASON = parseInt(process.env.CURRENT_SEASON || '2024', 10);
+
+const getFixtures = async ({ season = SEASON } = {}) => {
+  return getFixturesBySeason(TEAM_ID, season);
+};
+
+const getRecent = async ({ limit = 10, season = SEASON } = {}) => {
+  return getRecentFixtures(TEAM_ID, season, limit);
+};
+
+const getUpcoming = async ({ limit = 5, season = SEASON } = {}) => {
+  return getUpcomingFixtures(TEAM_ID, season, limit);
+};
+
+const getFixtureDetail = async (id) => {
+  const fixture = await getFixtureById(id);
+  if (!fixture) return null;
+
+  const [events, statistics] = await Promise.all([
+    getFixtureEvents(id),
+    getFixtureStatistics(id),
+  ]);
+
+  return { fixture, events, statistics };
+};
+
+module.exports = { getFixtures, getRecent, getUpcoming, getFixtureDetail };

--- a/src/services/players.service.js
+++ b/src/services/players.service.js
@@ -1,1 +1,14 @@
-// TODO: Players service
+const { getPlayersBySeason, getPlayerById } = require('../models/players.model');
+
+const TEAM_ID = parseInt(process.env.MUFC_TEAM_ID || '33', 10);
+const SEASON = parseInt(process.env.CURRENT_SEASON || '2024', 10);
+
+const getPlayers = async ({ season = SEASON } = {}) => {
+  return getPlayersBySeason(TEAM_ID, season);
+};
+
+const getPlayer = async (id, { season = SEASON } = {}) => {
+  return getPlayerById(id, season);
+};
+
+module.exports = { getPlayers, getPlayer };

--- a/src/services/standings.service.js
+++ b/src/services/standings.service.js
@@ -1,1 +1,10 @@
-// TODO: Standings service
+const { getStandings } = require('../models/standings.model');
+
+const LEAGUE_ID = parseInt(process.env.PREMIER_LEAGUE_ID || '39', 10);
+const SEASON = parseInt(process.env.CURRENT_SEASON || '2024', 10);
+
+const getLeagueStandings = async ({ season = SEASON, leagueId = LEAGUE_ID } = {}) => {
+  return getStandings(season, leagueId);
+};
+
+module.exports = { getLeagueStandings };

--- a/src/services/team.service.js
+++ b/src/services/team.service.js
@@ -1,1 +1,11 @@
-// TODO: Team service
+const { getTeamStats } = require('../models/team.model');
+
+const TEAM_ID = parseInt(process.env.MUFC_TEAM_ID || '33', 10);
+const LEAGUE_ID = parseInt(process.env.PREMIER_LEAGUE_ID || '39', 10);
+const SEASON = parseInt(process.env.CURRENT_SEASON || '2024', 10);
+
+const getStats = async ({ season = SEASON, leagueId = LEAGUE_ID } = {}) => {
+  return getTeamStats(TEAM_ID, season, leagueId);
+};
+
+module.exports = { getStats };


### PR DESCRIPTION
## Resumen
Capa de servicios que encapsula la lógica de negocio entre controllers y models.

## Issue relacionado
Closes #26

## Tipo de cambio
- [x] Feature nueva

## Cambios realizados
- `fixtures.service.js`: getFixtures, getRecent, getUpcoming, getFixtureDetail (fixture + events + stats en paralelo)
- `standings.service.js`: getLeagueStandings
- `players.service.js`: getPlayers, getPlayer
- `team.service.js`: getStats
- `analytics.service.js`: getOverview — agrega datos de 5 fuentes en paralelo, calcula form de últimos 5 partidos, expone uso de API del día

## Notas para el reviewer
- TEAM_ID/SEASON/LEAGUE_ID se leen de env en cada service — permite override por query param en el futuro
- `getOverview` usa `Promise.all` para las 5 queries en paralelo
- El cálculo de form en analytics ordena los recent por fecha asc (`.reverse()`) antes de mapear W/D/L

## Checklist
- [x] La rama está actualizada con `develop`
- [x] Listo para code review