### PR TITLE
feat: add service tests with model mocking

### DIFF
--- a/tests/services/analytics.service.test.js
+++ b/tests/services/analytics.service.test.js
@@ -1,0 +1,66 @@
+jest.mock('../../src/models/fixtures.model');
+jest.mock('../../src/models/standings.model');
+jest.mock('../../src/models/team.model');
+jest.mock('../../src/models/apiUsage.model');
+
+const { getRecentFixtures, getUpcomingFixtures } = require('../../src/models/fixtures.model');
+const { getStandings } = require('../../src/models/standings.model');
+const { getTeamStats } = require('../../src/models/team.model');
+const { getTodayUsage } = require('../../src/models/apiUsage.model');
+const { getOverview } = require('../../src/services/analytics.service');
+
+const MUFC_ID = 33;
+
+const makeFixture = (homeId, homeGoals, awayGoals) => ({
+  home_team_id: homeId,
+  away_team_id: homeId === MUFC_ID ? 42 : MUFC_ID,
+  home_goals: homeGoals,
+  away_goals: awayGoals,
+});
+
+describe('analytics.service — getOverview', () => {
+  beforeEach(() => {
+    process.env.MUFC_TEAM_ID = String(MUFC_ID);
+    process.env.PREMIER_LEAGUE_ID = '39';
+    process.env.CURRENT_SEASON = '2024';
+    process.env.API_DAILY_LIMIT = '100';
+    process.env.API_SAFETY_LIMIT = '95';
+
+    getUpcomingFixtures.mockResolvedValue([]);
+    getStandings.mockResolvedValue([{ team_id: MUFC_ID, rank: 8, points: 27 }]);
+    getTeamStats.mockResolvedValue({ goals_for_total: 22 });
+    getTodayUsage.mockResolvedValue({ request_count: 12 });
+  });
+
+  it('includes standing, upcoming and api_usage', async () => {
+    getRecentFixtures.mockResolvedValue([]);
+    const result = await getOverview();
+
+    expect(result.standing).toEqual({ team_id: MUFC_ID, rank: 8, points: 27 });
+    expect(result.upcoming_fixtures).toEqual([]);
+    expect(result.api_usage.requests_today).toBe(12);
+    expect(result.api_usage.daily_limit).toBe(100);
+  });
+
+  it('calculates form correctly from recent fixtures', async () => {
+    // model returns newest→oldest (ORDER BY date DESC)
+    // after .reverse() in service → oldest→newest: W, D, L, W, W
+    getRecentFixtures.mockResolvedValue([
+      makeFixture(MUFC_ID, 1, 0), // newest  → W (home)
+      makeFixture(42, 0, 3),      //         → W (away)
+      makeFixture(MUFC_ID, 0, 2), //         → L (home)
+      makeFixture(42, 1, 1),      //         → D (away)
+      makeFixture(MUFC_ID, 2, 0), // oldest  → W (home)
+    ]);
+
+    const result = await getOverview();
+    expect(result.form).toEqual(['W', 'D', 'L', 'W', 'W']);
+  });
+
+  it('sets api_usage to null when no usage record exists', async () => {
+    getRecentFixtures.mockResolvedValue([]);
+    getTodayUsage.mockResolvedValue(null);
+    const result = await getOverview();
+    expect(result.api_usage).toBeNull();
+  });
+});

--- a/tests/services/fixtures.service.test.js
+++ b/tests/services/fixtures.service.test.js
@@ -1,0 +1,86 @@
+jest.mock('../../src/models/fixtures.model');
+
+const {
+  getFixturesBySeason,
+  getRecentFixtures,
+  getUpcomingFixtures,
+  getFixtureById,
+  getFixtureEvents,
+  getFixtureStatistics,
+} = require('../../src/models/fixtures.model');
+
+const {
+  getFixtures,
+  getRecent,
+  getUpcoming,
+  getFixtureDetail,
+} = require('../../src/services/fixtures.service');
+
+const mockFixture = { id: 1, status_short: 'FT', home_goals: 2, away_goals: 1 };
+const mockEvents = [{ type: 'Goal' }];
+const mockStats = [{ stat_type: 'Ball Possession', stat_value: '54%' }];
+
+describe('fixtures.service', () => {
+  beforeEach(() => {
+    process.env.MUFC_TEAM_ID = '33';
+    process.env.CURRENT_SEASON = '2024';
+  });
+
+  describe('getFixtures', () => {
+    it('calls getFixturesBySeason with default season', async () => {
+      getFixturesBySeason.mockResolvedValue([mockFixture]);
+      const result = await getFixtures();
+      expect(getFixturesBySeason).toHaveBeenCalledWith(33, 2024);
+      expect(result).toEqual([mockFixture]);
+    });
+
+    it('forwards a custom season', async () => {
+      getFixturesBySeason.mockResolvedValue([]);
+      await getFixtures({ season: 2023 });
+      expect(getFixturesBySeason).toHaveBeenCalledWith(33, 2023);
+    });
+  });
+
+  describe('getRecent', () => {
+    it('calls getRecentFixtures with default limit', async () => {
+      getRecentFixtures.mockResolvedValue([mockFixture]);
+      await getRecent();
+      expect(getRecentFixtures).toHaveBeenCalledWith(33, 2024, 10);
+    });
+
+    it('forwards a custom limit', async () => {
+      getRecentFixtures.mockResolvedValue([]);
+      await getRecent({ limit: 5 });
+      expect(getRecentFixtures).toHaveBeenCalledWith(33, 2024, 5);
+    });
+  });
+
+  describe('getUpcoming', () => {
+    it('calls getUpcomingFixtures with default limit', async () => {
+      getUpcomingFixtures.mockResolvedValue([]);
+      await getUpcoming();
+      expect(getUpcomingFixtures).toHaveBeenCalledWith(33, 2024, 5);
+    });
+  });
+
+  describe('getFixtureDetail', () => {
+    it('returns null when fixture does not exist', async () => {
+      getFixtureById.mockResolvedValue(null);
+      const result = await getFixtureDetail(999);
+      expect(result).toBeNull();
+      expect(getFixtureEvents).not.toHaveBeenCalled();
+    });
+
+    it('returns fixture with events and statistics in parallel', async () => {
+      getFixtureById.mockResolvedValue(mockFixture);
+      getFixtureEvents.mockResolvedValue(mockEvents);
+      getFixtureStatistics.mockResolvedValue(mockStats);
+
+      const result = await getFixtureDetail(1);
+
+      expect(result).toEqual({ fixture: mockFixture, events: mockEvents, statistics: mockStats });
+      expect(getFixtureEvents).toHaveBeenCalledWith(1);
+      expect(getFixtureStatistics).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/tests/services/players.service.test.js
+++ b/tests/services/players.service.test.js
@@ -1,0 +1,37 @@
+jest.mock('../../src/models/players.model');
+
+const { getPlayersBySeason, getPlayerById } = require('../../src/models/players.model');
+const { getPlayers, getPlayer } = require('../../src/services/players.service');
+
+const mockPlayers = [{ id: 284060, name: 'Bruno Fernandes' }];
+
+describe('players.service', () => {
+  beforeEach(() => {
+    process.env.MUFC_TEAM_ID = '33';
+    process.env.CURRENT_SEASON = '2024';
+  });
+
+  describe('getPlayers', () => {
+    it('calls getPlayersBySeason with defaults', async () => {
+      getPlayersBySeason.mockResolvedValue(mockPlayers);
+      const result = await getPlayers();
+      expect(getPlayersBySeason).toHaveBeenCalledWith(33, 2024);
+      expect(result).toEqual(mockPlayers);
+    });
+  });
+
+  describe('getPlayer', () => {
+    it('returns the player when found', async () => {
+      getPlayerById.mockResolvedValue(mockPlayers[0]);
+      const result = await getPlayer(284060);
+      expect(getPlayerById).toHaveBeenCalledWith(284060, 2024);
+      expect(result).toEqual(mockPlayers[0]);
+    });
+
+    it('returns null when player does not exist', async () => {
+      getPlayerById.mockResolvedValue(null);
+      const result = await getPlayer(999);
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/tests/services/standings.service.test.js
+++ b/tests/services/standings.service.test.js
@@ -1,0 +1,29 @@
+jest.mock('../../src/models/standings.model');
+
+const { getStandings } = require('../../src/models/standings.model');
+const { getLeagueStandings } = require('../../src/services/standings.service');
+
+const mockStandings = [
+  { team_id: 33, rank: 8, points: 27 },
+  { team_id: 1, rank: 1, points: 52 },
+];
+
+describe('standings.service', () => {
+  beforeEach(() => {
+    process.env.PREMIER_LEAGUE_ID = '39';
+    process.env.CURRENT_SEASON = '2024';
+  });
+
+  it('calls getStandings with default season and leagueId', async () => {
+    getStandings.mockResolvedValue(mockStandings);
+    const result = await getLeagueStandings();
+    expect(getStandings).toHaveBeenCalledWith(2024, 39);
+    expect(result).toEqual(mockStandings);
+  });
+
+  it('forwards custom season and leagueId', async () => {
+    getStandings.mockResolvedValue([]);
+    await getLeagueStandings({ season: 2023, leagueId: 135 });
+    expect(getStandings).toHaveBeenCalledWith(2023, 135);
+  });
+});


### PR DESCRIPTION
## Resumen
15 tests para la capa de services, mockeando los modelos con jest.mock.

## Issue relacionado
Closes #35

## Tipo de cambio
- [x] Feature nueva

## Cambios realizados
- `fixtures.service.test.js`: 7 tests — getFixtures, getRecent, getUpcoming, getFixtureDetail (null cuando no existe, retorna fixture+events+stats en paralelo)
- `standings.service.test.js`: 2 tests — defaults y custom params
- `players.service.test.js`: 3 tests — getPlayers, getPlayer encontrado y no encontrado
- `analytics.service.test.js`: 3 tests — estructura del overview, cálculo correcto del form, api_usage null

## Notas para el reviewer
- El test del form descubrió que el mock debe proveer fixtures en orden DESC (como devuelve el modelo) para que el `.reverse()` del service funcione correctamente

## Checklist
- [x] 15/15 tests pasan
- [x] La rama está actualizada con `develop`
- [x] Listo para code review