### PR TITLE
feat: add integration tests for all routes with Supertest

### DIFF
--- a/tests/routes/analytics.routes.test.js
+++ b/tests/routes/analytics.routes.test.js
@@ -1,0 +1,42 @@
+jest.mock('../../src/services/analytics.service');
+
+const request = require('supertest');
+const app = require('../../src/app');
+const { getOverview } = require('../../src/services/analytics.service');
+
+describe('GET /api/analytics/overview', () => {
+  it('returns 200 with overview data', async () => {
+    const mockOverview = {
+      season: 2024,
+      form: ['W', 'D', 'W'],
+      standing: { rank: 8, points: 27 },
+      recent_fixtures: [],
+      upcoming_fixtures: [],
+      team_stats: {},
+      api_usage: { requests_today: 5, daily_limit: 100 },
+    };
+    getOverview.mockResolvedValue(mockOverview);
+
+    const res = await request(app).get('/api/analytics/overview');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.form).toEqual(['W', 'D', 'W']);
+    expect(res.body.data.api_usage.requests_today).toBe(5);
+  });
+
+  it('returns 500 when service throws', async () => {
+    getOverview.mockRejectedValue(new Error('DB error'));
+    const res = await request(app).get('/api/analytics/overview');
+    expect(res.status).toBe(500);
+    expect(res.body.success).toBe(false);
+  });
+});
+
+describe('GET /api/health', () => {
+  it('returns status ok', async () => {
+    const res = await request(app).get('/api/health');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('ok');
+    expect(res.body.success).toBe(true);
+  });
+});

--- a/tests/routes/fixtures.routes.test.js
+++ b/tests/routes/fixtures.routes.test.js
@@ -1,0 +1,57 @@
+jest.mock('../../src/services/fixtures.service');
+
+const request = require('supertest');
+const app = require('../../src/app');
+const { getFixtures, getRecent, getUpcoming, getFixtureDetail } = require('../../src/services/fixtures.service');
+
+const mockFixture = { id: 1035092, status_short: 'FT', home_goals: 1, away_goals: 0 };
+
+describe('GET /api/fixtures', () => {
+  it('returns 200 with fixture list', async () => {
+    getFixtures.mockResolvedValue([mockFixture]);
+    const res = await request(app).get('/api/fixtures');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toEqual([mockFixture]);
+    expect(res.body.meta.total).toBe(1);
+  });
+});
+
+describe('GET /api/fixtures/recent', () => {
+  it('returns 200 with recent fixtures', async () => {
+    getRecent.mockResolvedValue([mockFixture]);
+    const res = await request(app).get('/api/fixtures/recent?limit=5');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(getRecent).toHaveBeenCalledWith({ limit: 5, season: undefined });
+  });
+});
+
+describe('GET /api/fixtures/upcoming', () => {
+  it('returns 200 with upcoming fixtures', async () => {
+    getUpcoming.mockResolvedValue([]);
+    const res = await request(app).get('/api/fixtures/upcoming');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+  });
+});
+
+describe('GET /api/fixtures/:id', () => {
+  it('returns 200 with fixture detail', async () => {
+    getFixtureDetail.mockResolvedValue({
+      fixture: mockFixture,
+      events: [],
+      statistics: [],
+    });
+    const res = await request(app).get('/api/fixtures/1035092');
+    expect(res.status).toBe(200);
+    expect(res.body.data.fixture.id).toBe(1035092);
+  });
+
+  it('returns 404 when fixture does not exist', async () => {
+    getFixtureDetail.mockResolvedValue(null);
+    const res = await request(app).get('/api/fixtures/9999');
+    expect(res.status).toBe(404);
+    expect(res.body.success).toBe(false);
+  });
+});

--- a/tests/routes/players.routes.test.js
+++ b/tests/routes/players.routes.test.js
@@ -1,0 +1,33 @@
+jest.mock('../../src/services/players.service');
+
+const request = require('supertest');
+const app = require('../../src/app');
+const { getPlayers, getPlayer } = require('../../src/services/players.service');
+
+const mockPlayer = { id: 284060, name: 'Bruno Fernandes' };
+
+describe('GET /api/players', () => {
+  it('returns 200 with player list', async () => {
+    getPlayers.mockResolvedValue([mockPlayer]);
+    const res = await request(app).get('/api/players');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([mockPlayer]);
+    expect(res.body.meta.total).toBe(1);
+  });
+});
+
+describe('GET /api/players/:id', () => {
+  it('returns 200 with player detail', async () => {
+    getPlayer.mockResolvedValue(mockPlayer);
+    const res = await request(app).get('/api/players/284060');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(mockPlayer);
+  });
+
+  it('returns 404 when player not found', async () => {
+    getPlayer.mockResolvedValue(null);
+    const res = await request(app).get('/api/players/9999');
+    expect(res.status).toBe(404);
+    expect(res.body.success).toBe(false);
+  });
+});

--- a/tests/routes/standings.routes.test.js
+++ b/tests/routes/standings.routes.test.js
@@ -1,0 +1,24 @@
+jest.mock('../../src/services/standings.service');
+
+const request = require('supertest');
+const app = require('../../src/app');
+const { getLeagueStandings } = require('../../src/services/standings.service');
+
+describe('GET /api/standings', () => {
+  it('returns 200 with standings array', async () => {
+    const mockData = [{ team_id: 33, rank: 8, points: 27 }];
+    getLeagueStandings.mockResolvedValue(mockData);
+
+    const res = await request(app).get('/api/standings');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toEqual(mockData);
+    expect(res.body.meta.total).toBe(1);
+  });
+
+  it('forwards season query param', async () => {
+    getLeagueStandings.mockResolvedValue([]);
+    await request(app).get('/api/standings?season=2023');
+    expect(getLeagueStandings).toHaveBeenCalledWith({ season: 2023, leagueId: undefined });
+  });
+});

--- a/tests/routes/team.routes.test.js
+++ b/tests/routes/team.routes.test.js
@@ -1,0 +1,22 @@
+jest.mock('../../src/services/team.service');
+
+const request = require('supertest');
+const app = require('../../src/app');
+const { getStats } = require('../../src/services/team.service');
+
+describe('GET /api/team/stats', () => {
+  it('returns 200 with team stats', async () => {
+    const mockStats = { team_id: 33, goals_for_total: 22 };
+    getStats.mockResolvedValue(mockStats);
+    const res = await request(app).get('/api/team/stats');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toEqual(mockStats);
+  });
+
+  it('returns 404 when no stats exist', async () => {
+    getStats.mockResolvedValue(null);
+    const res = await request(app).get('/api/team/stats');
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Resumen
15 tests de integración HTTP con Supertest cubriendo los 10 endpoints de la API.

## Issue relacionado
Closes #37

## Tipo de cambio
- [x] Feature nueva

## Cambios realizados
- `fixtures.routes.test.js`: GET list, recent, upcoming, :id (200 y 404)
- `standings.routes.test.js`: GET list y forward de query params
- `players.routes.test.js`: GET list, :id (200 y 404)
- `team.routes.test.js`: GET stats (200 y 404)
- `analytics.routes.test.js`: GET overview (200), 500 cuando el service falla, health check

## Checklist
- [x] 55/55 tests pasan (suite completo)
- [x] La rama está actualizada con `develop`
- [x] Listo para code review