### PR TITLE
fix: resolve data integrity issues in fetchers and transformers (#45)

### DIFF
--- a/src/controllers/team.controller.js
+++ b/src/controllers/team.controller.js
@@ -1,4 +1,4 @@
-const { getStats } = require('../services/team.service');
+const { getStats, getInfo } = require('../services/team.service');
 
 const stats = async (req, res, next) => {
   try {
@@ -18,4 +18,22 @@ const stats = async (req, res, next) => {
   }
 };
 
-module.exports = { stats };
+const info = async (req, res, next) => {
+  try {
+    const { season, leagueId } = req.query;
+    const data = await getInfo({
+      season: season ? parseInt(season, 10) : undefined,
+      leagueId: leagueId ? parseInt(leagueId, 10) : undefined,
+    });
+    if (!data) {
+      const err = new Error('Team info not found');
+      err.status = 404;
+      return next(err);
+    }
+    res.json({ success: true, data });
+  } catch (err) {
+    next(err);
+  }
+};
+
+module.exports = { stats, info };

--- a/src/jobs/fetchers/fetchPlayerStats.js
+++ b/src/jobs/fetchers/fetchPlayerStats.js
@@ -22,7 +22,8 @@ const fetchPlayerStats = async () => {
     totalPages = response.data.paging?.total || 1;
 
     for (const p of players) {
-      await upsertPlayer(transformPlayer(p, SEASON, TEAM_ID));
+      const player = transformPlayer(p, SEASON, TEAM_ID);
+      if (player) await upsertPlayer(player);
     }
 
     totalSaved += players.length;

--- a/src/models/standings.model.js
+++ b/src/models/standings.model.js
@@ -61,4 +61,12 @@ const getStandings = async (season, leagueId) => {
   return rows;
 };
 
-module.exports = { upsertStanding, getStandings };
+const getTeamInfo = async (teamId, season, leagueId) => {
+  const [rows] = await pool.execute(
+    'SELECT team_id, team_name, team_logo FROM standings WHERE team_id = ? AND season = ? AND league_id = ? LIMIT 1',
+    [teamId, season, leagueId]
+  );
+  return rows[0] || null;
+};
+
+module.exports = { upsertStanding, getStandings, getTeamInfo };

--- a/src/routes/team.routes.js
+++ b/src/routes/team.routes.js
@@ -1,6 +1,7 @@
 const router = require('express').Router();
-const { stats } = require('../controllers/team.controller');
+const { stats, info } = require('../controllers/team.controller');
 
+router.get('/info', info);
 router.get('/stats', stats);
 
 module.exports = router;

--- a/src/services/analytics.service.js
+++ b/src/services/analytics.service.js
@@ -22,7 +22,7 @@ const getOverview = async () => {
     .slice()
     .reverse()
     .map((f) => {
-      if (f.home_goals === null) return null;
+      if (f.home_goals === null || f.away_goals === null) return null;
       const mufcIsHome = f.home_team_id === TEAM_ID;
       const mufcGoals = mufcIsHome ? f.home_goals : f.away_goals;
       const oppGoals = mufcIsHome ? f.away_goals : f.home_goals;

--- a/src/services/team.service.js
+++ b/src/services/team.service.js
@@ -1,4 +1,5 @@
 const { getTeamStats } = require('../models/team.model');
+const { getTeamInfo } = require('../models/standings.model');
 
 const TEAM_ID = parseInt(process.env.MUFC_TEAM_ID || '33', 10);
 const LEAGUE_ID = parseInt(process.env.PREMIER_LEAGUE_ID || '39', 10);
@@ -8,4 +9,8 @@ const getStats = async ({ season = SEASON, leagueId = LEAGUE_ID } = {}) => {
   return getTeamStats(TEAM_ID, season, leagueId);
 };
 
-module.exports = { getStats };
+const getInfo = async ({ season = SEASON, leagueId = LEAGUE_ID } = {}) => {
+  return getTeamInfo(TEAM_ID, season, leagueId);
+};
+
+module.exports = { getStats, getInfo };

--- a/src/utils/transformers.js
+++ b/src/utils/transformers.js
@@ -80,7 +80,8 @@ const transformStanding = (s, season, leagueId) => ({
 });
 
 const transformPlayer = (p, season, teamId) => {
-  const stats = p.statistics[0] || {};
+  if (!p.statistics?.length) return null;
+  const stats = p.statistics[0];
   return {
     id: p.player.id,
     name: p.player.name,

--- a/tests/routes/team.routes.test.js
+++ b/tests/routes/team.routes.test.js
@@ -2,7 +2,7 @@ jest.mock('../../src/services/team.service');
 
 const request = require('supertest');
 const app = require('../../src/app');
-const { getStats } = require('../../src/services/team.service');
+const { getStats, getInfo } = require('../../src/services/team.service');
 
 describe('GET /api/team/stats', () => {
   it('returns 200 with team stats', async () => {
@@ -18,5 +18,23 @@ describe('GET /api/team/stats', () => {
     getStats.mockResolvedValue(null);
     const res = await request(app).get('/api/team/stats');
     expect(res.status).toBe(404);
+  });
+});
+
+describe('GET /api/team/info', () => {
+  it('returns 200 with team info', async () => {
+    const mockInfo = { team_id: 33, team_name: 'Manchester United', team_logo: 'https://logo.com/mu.png' };
+    getInfo.mockResolvedValue(mockInfo);
+    const res = await request(app).get('/api/team/info');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toEqual(mockInfo);
+  });
+
+  it('returns 404 when team info not found', async () => {
+    getInfo.mockResolvedValue(null);
+    const res = await request(app).get('/api/team/info');
+    expect(res.status).toBe(404);
+    expect(res.body.success).toBe(false);
   });
 });

--- a/tests/unit/transformers.test.js
+++ b/tests/unit/transformers.test.js
@@ -210,6 +210,16 @@ describe('transformStanding', () => {
 });
 
 describe('transformPlayer', () => {
+  it('returns null when statistics array is empty', () => {
+    const playerWithNoStats = { ...apiPlayer, statistics: [] };
+    expect(transformPlayer(playerWithNoStats, 2024, 33)).toBeNull();
+  });
+
+  it('returns null when statistics is undefined', () => {
+    const playerWithNoStats = { ...apiPlayer, statistics: undefined };
+    expect(transformPlayer(playerWithNoStats, 2024, 33)).toBeNull();
+  });
+
   const result = transformPlayer(apiPlayer, 2024, 33);
 
   it('maps player identity fields', () => {


### PR DESCRIPTION
## Summary

Resolves data integrity issues found during code review of the fetcher and transformer layer, plus adds the missing `GET /api/team/info` endpoint.

## Changes

### Bug Fixes
- **`analytics.service.js`**: Form calculation now guards against `null` in both `home_goals` AND `away_goals`. Previously only `home_goals` was checked, which could cause incorrect W/D/L results when `away_goals` was null.
- **`transformers.js`**: `transformPlayer` now returns `null` when `statistics` is an empty array or undefined, instead of silently returning a player with all zeros.
- **`fetchPlayerStats.js`**: Skips null player transforms before calling `upsertPlayer`, preventing DB insertion of empty player records.

### New Feature
- **`GET /api/team/info`**: Returns basic MUFC team identity (`team_id`, `team_name`, `team_logo`) queried from the `standings` table. Covers the missing endpoint that the frontend calls as `/teams?id=33`.

## Test Plan
- [x] All 59 existing tests continue to pass
- [x] New unit tests for `transformPlayer` with empty/undefined statistics
- [x] New integration tests for `GET /api/team/info` (200 and 404 cases)

Closes #45